### PR TITLE
Fix sorting issue for TokenConfig and tokens, and small debugs for 2nd pool with DeployPool.s.sol

### DIFF
--- a/packages/foundry/script/DeployFactoryAndPool.s.sol
+++ b/packages/foundry/script/DeployFactoryAndPool.s.sol
@@ -8,7 +8,7 @@ import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {TokenConfig} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import {HelperConfig} from "../utils/HelperConfig.sol";
 import {ArrayHelpers} from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
-import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+import {InputHelpers} from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 /**
  * @title DeployFactoryAndPool
@@ -30,7 +30,7 @@ contract DeployFactoryAndPool is ScaffoldETHDeploy, DeployPool {
 
         // Deploy mock tokens. Remove this if using already deployed tokens and instead set the tokens above
         vm.startBroadcast(deployerPrivateKey);
-        (IERC20 token1, IERC20 token2) = deployMockTokens();
+        (address mockToken1, address mockToken2) = deployMockTokens();
         vm.stopBroadcast();
 
         // Look up configuration options from `HelperConfig.sol`
@@ -40,7 +40,7 @@ contract DeployFactoryAndPool is ScaffoldETHDeploy, DeployPool {
             string memory name,
             string memory symbol,
             TokenConfig[] memory tokenConfig
-        ) = helperConfig.getPoolConfig(token1, token2);
+        ) = helperConfig.getPoolConfig(mockToken1, mockToken2);
         (
             IERC20[] memory tokens,
             uint256[] memory exactAmountsIn,
@@ -81,5 +81,4 @@ contract DeployFactoryAndPool is ScaffoldETHDeploy, DeployPool {
          */
         exportDeployments();
     }
-
 }

--- a/packages/foundry/script/DeployPool.s.sol
+++ b/packages/foundry/script/DeployPool.s.sol
@@ -9,7 +9,7 @@ import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {TokenConfig} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import {DevOpsTools} from "lib/foundry-devops/src/DevOpsTools.sol";
 import {Script, console} from "forge-std/Script.sol";
-import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+import {InputHelpers} from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 import {HelperConfig} from "../utils/HelperConfig.sol";
 
 /**
@@ -35,25 +35,21 @@ contract DeployPool is HelperFunctions, HelperConfig, Script {
             );
         }
 
-        // Deploy mock tokens to use in the pool
-        vm.startBroadcast(deployerPrivateKey);
-        (IERC20 token1, IERC20 token2) = (IERC20(DevOpsTools.get_most_recent_deployment(
-            "MockToken1", // Must match the pool factory contract name
+        address mockToken1 = DevOpsTools.get_most_recent_deployment(
+            "MockToken1", // Must match the mock token contract name
             block.chainid
-        )),IERC20(DevOpsTools.get_most_recent_deployment(
-            "MockToken2", // Must match the pool factory contract name
+        );
+        address mockToken2 = DevOpsTools.get_most_recent_deployment(
+            "MockToken2", // Must match the mock token contract name
             block.chainid
-        ))); // Get the most recently deployed address of the pool factory)
-
-        vm.stopBroadcast();
+        );
 
         // Look up configurations from `HelperConfig.sol`
         HelperConfig helperConfig = new HelperConfig();
-        (
-            ,
-            ,
-            TokenConfig[] memory tokenConfig
-        ) = helperConfig.getPoolConfig(token1, token2);
+        (, , TokenConfig[] memory tokenConfig) = helperConfig.getPoolConfig(
+            mockToken1,
+            mockToken2
+        );
         (
             IERC20[] memory tokens,
             uint256[] memory exactAmountsIn,

--- a/packages/foundry/utils/HelperConfig.sol
+++ b/packages/foundry/utils/HelperConfig.sol
@@ -21,21 +21,13 @@ contract HelperConfig {
     IRouter public router = IRouter(0xA0De078cd5cFa7088821B83e0bD7545ccfb7c883);
 
     /**
-     * @dev Tokens for pool (also requires configuration of `TokenConfig` in the `getPoolConfig` function)
-     * @dev If using already deployed tokens, set the addresses here and remove the args for `getPoolConfig` function
-     * @notice the args for `getPoolConfig` enable the use of mock tokens that are not yet deployed
-     */
-    IERC20 mockToken1; // Make sure to have proper token order (alphanumeric)
-    IERC20 mockToken2; // Make sure to have proper token order (alphanumeric)
-
-    /**
      * @notice Creates mock tokens for the pool and mints 1000 of each to the deployer wallet
      */
-    function deployMockTokens() internal returns (IERC20, IERC20) {
+    function deployMockTokens() internal returns (address, address) {
         MockToken1 scUSD = new MockToken1("Scaffold USD", "scUSD");
         MockToken2 scDAI = new MockToken2("Scaffold DAI", "scDAI");
 
-        return (scDAI, scUSD);
+        return (address(scDAI), address(scUSD));
     }
 
     /**
@@ -53,8 +45,8 @@ contract HelperConfig {
      * @dev Set the name, symbol, and token configuration for the pool here
      */
     function getPoolConfig(
-        IERC20 token1,
-        IERC20 token2
+        address token1,
+        address token2
     )
         public
         pure
@@ -69,13 +61,13 @@ contract HelperConfig {
 
         tokenConfig = new TokenConfig[](2); // An array of descriptors for the tokens the pool will manage.
         tokenConfig[0] = TokenConfig({ // Make sure to have proper token order (alphanumeric)
-            token: token1,
+            token: IERC20(token1),
             tokenType: TokenType.STANDARD, // STANDARD, WITH_RATE, or ERC4626
             rateProvider: IRateProvider(address(0)), // The rate provider for a token
             yieldFeeExempt: false // Flag indicating whether yield fees should be charged on this token
         });
         tokenConfig[1] = TokenConfig({ // Make sure to have proper token order (alphanumeric)
-            token: token2,
+            token: IERC20(token2),
             tokenType: TokenType.STANDARD, // STANDARD, WITH_RATE, or ERC4626
             rateProvider: IRateProvider(address(0)), // The rate provider for a token
             yieldFeeExempt: false // Flag indicating whether yield fees should be charged on this token
@@ -109,12 +101,17 @@ contract HelperConfig {
         userData = bytes(""); // Additional (optional) data required for adding initial liquidity
     }
 
-    function sortTokenConfig(TokenConfig[] memory tokenConfig) public pure returns (TokenConfig[] memory) {
+    function sortTokenConfig(
+        TokenConfig[] memory tokenConfig
+    ) public pure returns (TokenConfig[] memory) {
         for (uint256 i = 0; i < tokenConfig.length - 1; i++) {
             for (uint256 j = 0; j < tokenConfig.length - i - 1; j++) {
                 if (tokenConfig[j].token > tokenConfig[j + 1].token) {
                     // Swap if they're out of order.
-                    (tokenConfig[j], tokenConfig[j + 1]) = (tokenConfig[j + 1], tokenConfig[j]);
+                    (tokenConfig[j], tokenConfig[j + 1]) = (
+                        tokenConfig[j + 1],
+                        tokenConfig[j]
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Description

_Small PR to fix sorting issue mentioned in PR #38 && reversion when running `yarn deploy:pool` after running `yarn deploy:all` where the same `name` and `symbol` was used btw the two scripts and resultant pools._

## Additional Information

- [x] Fix sorting issue
- [x] Hardcode name and symbol for second pool in `DeployPool.s.sol`
- [x] Have the second pool, or any pool created with `DeployPool.s.sol` use the latest `MockToken1` and `MockToken2` so user can troubleshoot with ScaffoldBalancer local front end and use the same ERC20s to play with their pools.
   _- NOTE: these changes makes things work for two pool deployments. If the user wants to deploy more than 2 pools they'll need to change the name and symbol within `DeployPool.s.sol` at the very least each time. We can make this an improvement for post-milestone 1._