### PR TITLE
Fix a typo in the Testing Hooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ yarn test --match-contract ConstantSumPoolTest
 
 ### 3. Testing Hooks 🎣
 
-The `VeBALFeeDiscountHookTest` mirrors the [VeBALFeeDiscountHookExampleTest](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/pool-hooks/test/foundry/VeBALFeeDiscountHookExample.t.sol)
+The `VeBALFeeDiscountHookExampleTest` mirrors the [VeBALFeeDiscountHookExampleTest](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/pool-hooks/test/foundry/VeBALFeeDiscountHookExample.t.sol)
 
 ```
-yarn test --match-contract VeBALFeeDiscountHookTest
+yarn test --match-contract VeBALFeeDiscountHookExampleTest
 ```


### PR DESCRIPTION
## Description

Due to a typo in a contract name, the test could not be run with the command from the README.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: 0x1672ce7eb8Eb6b699875F3f96E369812Adc558BC
